### PR TITLE
fix: Add write permission to default scopes

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -37,7 +37,7 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    protected $scopes = ['offline_access', 'read'];
+    protected $scopes = ['offline_access', 'read', 'write'];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This solves 401 unauthorized_scopes errors in all PUT or POST requests to mercadolibre API.